### PR TITLE
test : search test 보강

### DIFF
--- a/Test_EmployeeManager/TestBirthdayDaySearch.cpp
+++ b/Test_EmployeeManager/TestBirthdayDaySearch.cpp
@@ -2,20 +2,25 @@
 #include "TestSearch.h"
 #include "../EmployeeManager/BirthdayDaySearch.cpp"
 
-TEST_F(TestSearch, TestBirthdayDaySearchInvalid) {
+using TestBirthdayDaySearch = TestSearch;
+
+TEST_F(TestBirthdayDaySearch, TestBirthdayDaySearchInvalid) {
 	auto searcher = make_unique<BirthdayDaySearch>();
 	auto results = searcher->search(*employeeMap, Inform{ "birthday_day", "32" });
 	EXPECT_EQ(0, results->size());
 }
 
-TEST_F(TestSearch, TestBirthdayDaySearchNotExist) {
+TEST_F(TestBirthdayDaySearch, TestBirthdayDaySearchNotExist) {
 	auto searcher = make_unique<BirthdayDaySearch>();
 	auto results = searcher->search(*employeeMap, Inform{ "birthday_day", "07" });
 	EXPECT_EQ(0, results->size());
 }
 
-TEST_F(TestSearch, TestBirthdayDaySearchExist) {
+TEST_F(TestBirthdayDaySearch, TestBirthdayDaySearchExist) {
 	auto searcher = make_unique<BirthdayDaySearch>();
 	auto results = searcher->search(*employeeMap, Inform{ "birthday_day", "03" });
 	EXPECT_EQ(3, results->size());
+	EXPECT_EQ("1999112233", (*results)[0].employee_num);
+	EXPECT_EQ("2001001122", (*results)[1].employee_num);
+	EXPECT_EQ("2001112233", (*results)[2].employee_num);
 }

--- a/Test_EmployeeManager/TestBirthdayMonthSearch.cpp
+++ b/Test_EmployeeManager/TestBirthdayMonthSearch.cpp
@@ -2,20 +2,24 @@
 #include "TestSearch.h"
 #include "../EmployeeManager/BirthdayMonthSearch.cpp"
 
-TEST_F(TestSearch, TestBirthdayMonthSearchInvalid) {
+using TestBirthdayMonthSearch = TestSearch;
+
+TEST_F(TestBirthdayMonthSearch, TestBirthdayMonthSearchInvalid) {
 	auto searcher = make_unique<BirthdayMonthSearch>();
 	auto results = searcher->search(*employeeMap, Inform{ "birthday_month", "13" });
 	EXPECT_EQ(0, results->size());
 }
 
-TEST_F(TestSearch, TestBirthdayMonthSearchNotExist) {
+TEST_F(TestBirthdayMonthSearch, TestBirthdayMonthSearchNotExist) {
 	auto searcher = make_unique<BirthdayMonthSearch>();
 	auto results = searcher->search(*employeeMap, Inform{ "birthday_month", "07" });
 	EXPECT_EQ(0, results->size());
 }
 
-TEST_F(TestSearch, TestBirthdayMonthSearchExist) {
+TEST_F(TestBirthdayMonthSearch, TestBirthdayMonthSearchExist) {
 	auto searcher = make_unique<BirthdayMonthSearch>();
 	auto results = searcher->search(*employeeMap, Inform{ "birthday_month", "02" });
 	EXPECT_EQ(2, results->size());
+	EXPECT_EQ("1999112233", (*results)[0].employee_num);
+	EXPECT_EQ("2001001122", (*results)[1].employee_num);
 }

--- a/Test_EmployeeManager/TestBirthdaySearch.cpp
+++ b/Test_EmployeeManager/TestBirthdaySearch.cpp
@@ -2,20 +2,23 @@
 #include "TestSearch.h"
 #include "../EmployeeManager/BirthdaySearch.cpp"
 
-TEST_F(TestSearch, TestBirthdaySearchInvalid) {
+using TestBirthdaySearch = TestSearch;
+
+TEST_F(TestBirthdaySearch, TestBirthdaySearchInvalid) {
 	auto searcher = make_unique<BirthdaySearch>();
 	auto results = searcher->search(*employeeMap, Inform{ "birthday", "20000000" });
 	EXPECT_EQ(0, results->size());
 }
 
-TEST_F(TestSearch, TestBirthdaySearchNotExist) {
+TEST_F(TestBirthdaySearch, TestBirthdaySearchNotExist) {
 	auto searcher = make_unique<BirthdaySearch>();
 	auto results = searcher->search(*employeeMap, Inform{ "birthday", "20000101" });
 	EXPECT_EQ(0, results->size());
 }
 
-TEST_F(TestSearch, TestBirthdaySearchExist) {
+TEST_F(TestBirthdaySearch, TestBirthdaySearchExist) {
 	auto searcher = make_unique<BirthdaySearch>();
 	auto results = searcher->search(*employeeMap, Inform{ "birthday", "20010103" });
 	EXPECT_EQ(1, results->size());
+	EXPECT_EQ("2001112233", (*results)[0].employee_num);
 }

--- a/Test_EmployeeManager/TestBirthdayYearSearch.cpp
+++ b/Test_EmployeeManager/TestBirthdayYearSearch.cpp
@@ -2,20 +2,24 @@
 #include "TestSearch.h"
 #include "../EmployeeManager/BirthdayYearSearch.cpp"
 
-TEST_F(TestSearch, TestBirthdayYearSearchInvalid) {
+using TestBirthdayYearSearch = TestSearch;
+
+TEST_F(TestBirthdayYearSearch, TestBirthdayYearSearchInvalid) {
 	auto searcher = make_unique<BirthdayYearSearch>();
 	auto results = searcher->search(*employeeMap, Inform{ "birthday_year", "20000000" });
 	EXPECT_EQ(0, results->size());
 }
 
-TEST_F(TestSearch, TestBirthdayYearSearchNotExist) {
+TEST_F(TestBirthdayYearSearch, TestBirthdayYearSearchNotExist) {
 	auto searcher = make_unique<BirthdayYearSearch>();
 	auto results = searcher->search(*employeeMap, Inform{ "birthday_year", "1998" });
 	EXPECT_EQ(0, results->size());
 }
 
-TEST_F(TestSearch, TestBirthdayYearSearchExist) {
+TEST_F(TestBirthdayYearSearch, TestBirthdayYearSearchExist) {
 	auto searcher = make_unique<BirthdayYearSearch>();
 	auto results = searcher->search(*employeeMap, Inform{ "birthday_year", "2000" });
 	EXPECT_EQ(2, results->size());
+	EXPECT_EQ("2000112233", (*results)[0].employee_num);
+	EXPECT_EQ("2001001122", (*results)[1].employee_num);
 }

--- a/Test_EmployeeManager/TestCertiSearch.cpp
+++ b/Test_EmployeeManager/TestCertiSearch.cpp
@@ -2,20 +2,24 @@
 #include "TestSearch.h"
 #include "../EmployeeManager/CertiSearch.cpp"
 
-TEST_F(TestSearch, TestCertiSearchInvalid) {
+using TestCertiSearch = TestSearch;
+
+TEST_F(TestCertiSearch, TestCertiSearchInvalid) {
 	auto searcher = make_unique<CertiSearch>();
 	auto results = searcher->search(*employeeMap, Inform{ "certi", "ABC" });
 	EXPECT_EQ(0, results->size());
 }
 
-TEST_F(TestSearch, TestCertiSearchNotExist) {
+TEST_F(TestCertiSearch, TestCertiSearchNotExist) {
 	auto searcher = make_unique<CertiSearch>();
 	auto results = searcher->search(*employeeMap, Inform{ "certi", "ADV" });
 	EXPECT_EQ(0, results->size());
 }
 
-TEST_F(TestSearch, TestCertiSearchExist) {
+TEST_F(TestCertiSearch, TestCertiSearchExist) {
 	auto searcher = make_unique<CertiSearch>();
 	auto results = searcher->search(*employeeMap, Inform{ "certi", "EX" });
 	EXPECT_EQ(2, results->size());
+	EXPECT_EQ("1999112233", (*results)[0].employee_num);
+	EXPECT_EQ("2001001122", (*results)[1].employee_num);
 }

--- a/Test_EmployeeManager/TestClSearch.cpp
+++ b/Test_EmployeeManager/TestClSearch.cpp
@@ -3,20 +3,24 @@
 #include "../EmployeeManager/Search.h"
 #include "../EmployeeManager/ClSearch.cpp"
 
-TEST_F(TestSearch, TestClSearchInvalid) {
+using TestClSearch = TestSearch;
+
+TEST_F(TestClSearch, TestClSearchInvalid) {
 	auto searcher = make_unique<ClSearch>();
 	auto results = searcher->search(*employeeMap, Inform{ "cl", "CL0" });
 	EXPECT_EQ(0, results->size());
 }
 
-TEST_F(TestSearch, TestClSearchNotExist) {
+TEST_F(TestClSearch, TestClSearchNotExist) {
 	auto searcher = make_unique<ClSearch>();
 	auto results = searcher->search(*employeeMap, Inform{ "cl", "CL4" });
 	EXPECT_EQ(0, results->size());
 }
 
-TEST_F(TestSearch, TestClSearchExist) {
+TEST_F(TestClSearch, TestClSearchExist) {
 	auto searcher = make_unique<ClSearch>();
 	auto results = searcher->search(*employeeMap, Inform{ "cl", "CL1" });
 	EXPECT_EQ(2, results->size());
+	EXPECT_EQ("2000112233", (*results)[0].employee_num);
+	EXPECT_EQ("2001001122", (*results)[1].employee_num);
 }

--- a/Test_EmployeeManager/TestEmployeeNumSearch.cpp
+++ b/Test_EmployeeManager/TestEmployeeNumSearch.cpp
@@ -5,7 +5,7 @@
 using TestEmployeeNumSearch = TestSearch;
 TEST_F(TestEmployeeNumSearch, TestSearchItem) {
 	auto searcher = make_unique<EmployeeNumSearch>();
-	Inform inform = { "employeeNum","00112233" };
+	Inform inform = { "employeeNum","2000112233" };
 	auto result = searcher->search(*employeeMap, inform);
 	EXPECT_EQ(1, result->size());
 }

--- a/Test_EmployeeManager/TestFirstNameSearch.cpp
+++ b/Test_EmployeeManager/TestFirstNameSearch.cpp
@@ -17,8 +17,8 @@ TEST_F(TestFirstNameSearch, TestSearchManyItem) {
 	Inform inform = { "name_first", "Gyoungrae" };
 	auto result = searcher->search(*employeeMap, inform);
 	EXPECT_EQ(2, result->size());
-	EXPECT_EQ("01001122", (*result)[0].employee_num);
-	EXPECT_EQ("99112233", (*result)[1].employee_num);
+	EXPECT_EQ("1999112233", (*result)[0].employee_num);
+	EXPECT_EQ("2001001122", (*result)[1].employee_num);
 }
 
 TEST_F(TestFirstNameSearch, TestWrongName) {

--- a/Test_EmployeeManager/TestLastNameSearch.cpp
+++ b/Test_EmployeeManager/TestLastNameSearch.cpp
@@ -17,9 +17,9 @@ TEST_F(TestLastNameSearch, TestSearchManyItem) {
 	Inform inform = { "name_last", "Hong" };
 	auto result = searcher->search(*employeeMap, inform);
 	EXPECT_EQ(3, result->size());
-	EXPECT_EQ("00112233", (*result)[0].employee_num); 
-	EXPECT_EQ("01001122", (*result)[1].employee_num);
-	EXPECT_EQ("99112233", (*result)[2].employee_num);
+	EXPECT_EQ("1999112233", (*result)[0].employee_num);
+	EXPECT_EQ("2000112233", (*result)[1].employee_num); 
+	EXPECT_EQ("2001001122", (*result)[2].employee_num);
 }
 
 TEST_F(TestLastNameSearch, TestWrongName) {

--- a/Test_EmployeeManager/TestSearch.h
+++ b/Test_EmployeeManager/TestSearch.h
@@ -8,26 +8,26 @@ protected:
 	void SetUp() override {
 		employeeMap = make_unique<EmployeeMap>();
 
-		employeeMap->insert({ "00112233",
-			move(make_unique<Employee>(Employee{"00112233", "Gildong Hong", "Gildong", "Hong",
+		employeeMap->insert({ "2000112233",
+			move(make_unique<Employee>(Employee{"2000112233", "Gildong Hong", "Gildong", "Hong",
 				"010-1234-5678", "1234", "5678",
 				"20000102", "2000", "01", "02",
 				"CL1", "PRO" })) });
 
-		employeeMap->insert({ "01112233",
-			move(make_unique<Employee>(Employee{"01112233", "Choonhyang Seong", "Choonhyang", "Seong",
+		employeeMap->insert({ "2001112233",
+			move(make_unique<Employee>(Employee{"2001112233", "Choonhyang Seong", "Choonhyang", "Seong",
 				"010-4321-5678", "4321", "5678",
 				"20010103", "2001", "01", "03",
 				"CL2", "PRO" })) });
 
-		employeeMap->insert({ "01001122",
-			move(make_unique<Employee>(Employee{"01001122", "Gyoungrae Hong", "Gyoungrae", "Hong",
+		employeeMap->insert({ "2001001122",
+			move(make_unique<Employee>(Employee{"2001001122", "Gyoungrae Hong", "Gyoungrae", "Hong",
 				"010-1234-6789", "1234", "6789",
 				"20000203", "2000", "02", "03",
 				"CL1", "EX" })) });
 
-		employeeMap->insert({ "99112233",
-			move(make_unique<Employee>(Employee{"99112233", "Gyoungrae Hong", "Gyoungrae", "Hong",
+		employeeMap->insert({ "1999112233",
+			move(make_unique<Employee>(Employee{"1999112233", "Gyoungrae Hong", "Gyoungrae", "Hong",
 				"010-0000-0001", "0000", "0001",
 				"19990203", "1999", "02", "03",
 				"CL3", "EX" })) });


### PR DESCRIPTION
1. using을 이용하여 Test case name 구분
2. 기존 개수만 확인하는 test 로직에서 내용까지 확인하도록 보강
3. 사번의 저장 format 변경 사항 적용